### PR TITLE
[ENG-4078] [ENG-4079] Expose AgGridAPI in namespace

### DIFF
--- a/custom_components/reflex_ag_grid/ag_grid.py
+++ b/custom_components/reflex_ag_grid/ag_grid.py
@@ -105,6 +105,18 @@ class ColumnGroup(PropsBase):
 class AgGridAPI(rx.Base):
     ref: str
 
+    @classmethod
+    def create(cls, id: str) -> "AgGridAPI":
+        """Create an instance of the AgGridAPI class.
+
+        Args:
+            id: The ID of the AgGrid component.
+
+        Returns:
+            An instance of the AgGridAPI class.
+        """
+        return cls(ref=rx.utils.format.format_ref(id))
+
     @property
     def _api(self) -> rx.Var:
         return f"refs['{self.ref}']?.current?.api"
@@ -112,18 +124,18 @@ class AgGridAPI(rx.Base):
     def __getattr__(self, name: str) -> Callable[[Any], rx.event.EventSpec]:
         def _call_api(*args, **kwargs) -> rx.event.EventSpec:
             """Call the ag-grid API method with the given arguments.
-            
+
             Args:
                 *args: Arguments to pass to the API method.
                 **kwargs: Keyword arguments to pass to rx.call_script.
-            
+
             Returns:
                 rx.event.EventSpec: The event specification.
             """
             var_args = [str(rx.Var.create(arg)) for arg in args]
             return rx.call_script(
                 f"{self._api}.{rx.utils.format.to_camel_case(name)}({', '.join(var_args)})",
-                **kwargs
+                **kwargs,
             )
 
         return _call_api
@@ -453,6 +465,7 @@ class WrappedAgGrid(AgGrid):
 
 
 class AgGridNamespace(rx.ComponentNamespace):
+    api = AgGridAPI.create
     column_def = ColumnDef
     column_group = ColumnGroup
     filters = AGFilters


### PR DESCRIPTION
Expose the AgGridAPI in the namespace and define a `create` function which accepts an `id`, formatting it appropriately as a ref.